### PR TITLE
Added additional flags to Makevars to allow compilation on Mac

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 STANHEADERS_SRC = $(shell "$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" -e "message()" -e "cat(system.file('include', 'src', package = 'StanHeaders', mustWork = TRUE))" -e "message()" | grep "StanHeaders")
-PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
+PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error -DUSE_STANC3 -D_DARWIN_C_SOURCE -D_REENTRANT
 CXX_STD = CXX14
 SOURCES = $(wildcard stan_files/*.stan)
 OBJECTS = $(SOURCES:.stan=.o) init.o


### PR DESCRIPTION
I assume this is similar to Wes' update for the windows Makevars. Added flags to solve two errors: one which shows that the `validate_dims` member cannot be found (-DUSE_STANC3) and another which shows that the lgamma functions from the boost(?) library cannot be found (-DUSE_DARWIN_C_SOURCE and -D_REENTRANT).