### PR TITLE
Add license

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 2.0
 Author: Nathanael Hoze
 Maintainer: Nathanael Hoze <nathanael.hoze@gmail.com>
 Description: Fit models of the force of infection to serological data using Bayesian MCMC methods. The package provides a standardized format for handling serological data, contains various serocatalytic models of force of infection, fits the models to the data, and provides tools to analyse and plot the results of the fits.  
-License: What license is it under?
+License: GPL (>= 3)
 Depends: 
 	R (>= 4.0.2), 
 	Rcpp (>= 0.12.13), 

--- a/README.Rmd
+++ b/README.Rmd
@@ -159,3 +159,7 @@ The following schematic summarizes the different functions available with the pa
 
 
 
+
+## License
+
+*Rsero* is released under the [GPL (>= 3)](https://www.gnu.org/licenses/gpl-3.0.html) license. © Nathanael Hoze.

--- a/README.md
+++ b/README.md
@@ -275,3 +275,7 @@ A full running example is available
 
 The following schematic summarizes the different functions available
 with the package <img src="/schema.png" width="1000" />
+
+## License
+
+*Rsero* is released under the [GPL (>= 3)](https://www.gnu.org/licenses/gpl-3.0.html) license. © Nathanael Hoze.


### PR DESCRIPTION
Hi @nathoze -- I was doing a survey of epi modeling tools on behalf of the Global Society for Infectious Disease Dynamics ([gsidd.org](https://gsidd.org)), and came across Rsero. I noticed it didn't have a license, so this PR adds it. I chose GPL since the codebase includes two GPL-licensed utilities (`stanmodels.R` and `make_cc.R`), so legally this package would need to be released under GPL as well. (Note: I used AI to do the tool survey, which also flagged the missing license, but I verified the issue and changes myself.)